### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
 
-* @michaelkaplan13 @cam-schultz @minghinmatthewlam @geoff-vball @bernard-avalabs @feuGeneA
+* @ava-labs/interop


### PR DESCRIPTION
## Why this should be merged
Replaces individuals with the @ava-labs/interop team, who each get requested as reviewers individually.