### PR TITLE
Fix audit link

### DIFF
--- a/audits/README.md
+++ b/audits/README.md
@@ -4,5 +4,5 @@ Please check out __only__ listed audited version for production code.
 
 | Date         | Version | Commit     | Auditor      | Scope                | Links                                                       |
 | ------------ | ------- | ---------- | ------------ | -------------------- | ----------------------------------------------------------- |
-| June 2024    | v1.0.0  | `9e03a1e5` | OpenZeppelin | All contracts in `contracts/src/` excluding `mocks/` | [🔗](./OpenZeppelin-Audit-2024-06-24.pdf) |
+| June 2024    | v1.0.0  | `9e03a1e5` | OpenZeppelin | All contracts in `contracts/src/` excluding `mocks/` | [🔗](./OpenZeppelin%20Audit%20(June%2026th%202024).pdf) |
 


### PR DESCRIPTION
## Why this should be merged

Replaces https://github.com/ava-labs/avalanche-interchain-token-transfer/pull/193 with a signed commit.

Thanks to @henrygagnier for originally catching and fixing this.