### PR TITLE
tests/utils/warpConfig: non-zero block timestamp

### DIFF
--- a/tests/utils/warp-genesis-template.json
+++ b/tests/utils/warp-genesis-template.json
@@ -22,7 +22,7 @@
       "blockGasCostStep": 500000
     },
     "warpConfig": {
-      "blockTimestamp": 0
+      "blockTimestamp": 1719343601
     },
     "contractNativeMinterConfig": {
       "blockTimestamp": 0,


### PR DESCRIPTION
## Why this should be merged
see https://github.com/ava-labs/teleporter/pull/401#discussion_r1668932963