### PR TITLE
use fewer validator nodes in e2e tests

### DIFF
--- a/tests/local/e2e_test.go
+++ b/tests/local/e2e_test.go
@@ -51,15 +51,15 @@ var _ = ginkgo.BeforeSuite(func() {
 			{
 				Name:       "A",
 				EVMChainID: 12345,
-				NodeCount:  5,
+				NodeCount:  1,
 			},
 			{
 				Name:       "B",
 				EVMChainID: 54321,
-				NodeCount:  5,
+				NodeCount:  1,
 			},
 		},
-		5,
+		0,
 	)
 
 	// Generate the Teleporter deployment values


### PR DESCRIPTION
## Why this should be merged
Because it speeds up the e2e tests. In my local environment, it reduced test time from 5m30s to 4m47s.

## How this works
Reduces the number of validator nodes to just 1 for subnetA and 1 for subnetB (and passing 0 for `extraNodes`).

## How this was tested
With the existing test suite

## How is this documented
By the code itself