### PR TITLE
Reentrancy visibility

### DIFF
--- a/contracts/src/utils/SendReentrancyGuard.sol
+++ b/contracts/src/utils/SendReentrancyGuard.sol
@@ -43,8 +43,8 @@ abstract contract SendReentrancyGuard is Initializable {
         }
     }
 
-    uint256 internal constant _NOT_ENTERED = 1;
-    uint256 internal constant _ENTERED = 2;
+    uint256 private constant _NOT_ENTERED = 1;
+    uint256 private constant _ENTERED = 2;
 
     // sendNonReentrant modifier makes sure there is not reentry between {_send} or {_sendAndCall} calls.
     modifier sendNonReentrant() {

--- a/contracts/src/utils/SendReentrancyGuard.sol
+++ b/contracts/src/utils/SendReentrancyGuard.sol
@@ -25,6 +25,9 @@ abstract contract SendReentrancyGuard is Initializable {
     struct SendReentrancyGuardStorage {
         uint256 _sendEntered;
     }
+
+    uint256 internal constant NOT_ENTERED = 1;
+    uint256 internal constant ENTERED = 2;
     // solhint-enable private-vars-leading-underscore
 
     // keccak256(abi.encode(uint256(keccak256("avalanche-ictt.storage.SendReentrancyGuard")) - 1)) & ~bytes32(uint256(0xff));

--- a/contracts/src/utils/SendReentrancyGuard.sol
+++ b/contracts/src/utils/SendReentrancyGuard.sol
@@ -25,9 +25,6 @@ abstract contract SendReentrancyGuard is Initializable {
     struct SendReentrancyGuardStorage {
         uint256 _sendEntered;
     }
-
-    uint256 internal constant NOT_ENTERED = 1;
-    uint256 internal constant ENTERED = 2;
     // solhint-enable private-vars-leading-underscore
 
     // keccak256(abi.encode(uint256(keccak256("avalanche-ictt.storage.SendReentrancyGuard")) - 1)) & ~bytes32(uint256(0xff));


### PR DESCRIPTION
## Why this should be merged
These constants should only be used within the reentrancy guard contract. Also if you inherit multiple ReentrancyGuards that define the same constant it'd conflict, but is okay right now because OZ's constants used are private.

## How this works

## How this was tested

## How is this documented
